### PR TITLE
Implement CRUD views for domain models

### DIFF
--- a/farmacia_project/farmacia/urls.py
+++ b/farmacia_project/farmacia/urls.py
@@ -1,10 +1,52 @@
 from django.urls import path
-from .views import login_view, dashboard_view, pacientes_view, medicos_view, pedidos_view
+from .views import (
+    login_view,
+    dashboard_view,
+    PacienteListView,
+    PacienteCreateView,
+    PacienteUpdateView,
+    PacienteDeleteView,
+    MedicoListView,
+    MedicoCreateView,
+    MedicoUpdateView,
+    MedicoDeleteView,
+    PedidoListView,
+    PedidoCreateView,
+    PedidoUpdateView,
+    PedidoDeleteView,
+)
 
 urlpatterns = [
-    path('login/', login_view, name='login'),
-    path('dashboard/', dashboard_view, name='dashboard'),
-    path('pacientes/', pacientes_view, name='pacientes'),    
-    path('medicos/', medicos_view, name='medicos'),    
-    path('pedidos/', pedidos_view, name='pedidos'),    
+    path("login/", login_view, name="login"),
+    path("dashboard/", dashboard_view, name="dashboard"),
+
+    # Pacientes
+    path("pacientes/", PacienteListView.as_view(), name="paciente_list"),
+    path("pacientes/novo/", PacienteCreateView.as_view(), name="paciente_create"),
+    path("pacientes/<int:pk>/editar/", PacienteUpdateView.as_view(), name="paciente_update"),
+    path(
+        "pacientes/<int:pk>/excluir/",
+        PacienteDeleteView.as_view(),
+        name="paciente_delete",
+    ),
+
+    # Médicos
+    path("medicos/", MedicoListView.as_view(), name="medico_list"),
+    path("medicos/novo/", MedicoCreateView.as_view(), name="medico_create"),
+    path("medicos/<int:pk>/editar/", MedicoUpdateView.as_view(), name="medico_update"),
+    path(
+        "medicos/<int:pk>/excluir/",
+        MedicoDeleteView.as_view(),
+        name="medico_delete",
+    ),
+
+    # Pedidos
+    path("pedidos/", PedidoListView.as_view(), name="pedido_list"),
+    path("pedidos/novo/", PedidoCreateView.as_view(), name="pedido_create"),
+    path("pedidos/<int:pk>/editar/", PedidoUpdateView.as_view(), name="pedido_update"),
+    path(
+        "pedidos/<int:pk>/excluir/",
+        PedidoDeleteView.as_view(),
+        name="pedido_delete",
+    ),
 ]

--- a/farmacia_project/farmacia/views.py
+++ b/farmacia_project/farmacia/views.py
@@ -1,4 +1,13 @@
 from django.shortcuts import render
+from django.urls import reverse_lazy
+from django.views.generic import (
+    ListView,
+    CreateView,
+    UpdateView,
+    DeleteView,
+)
+
+from .models import Paciente, Medico, Pedido
 
 def login_view(request):
     return render(request, 'login.html')
@@ -12,11 +21,139 @@ def pacientes_view(request):
 def medicos_view(request):
     return render(request, 'medicos.html')
 
-from django.shortcuts import render
-
 def pedidos_view(request):
     context = {
         'titulo': 'Gestão de Pedidos',
         # Outros dados que quiser passar para o template
     }
     return render(request, 'pedidos.html', context)
+
+
+class PacienteListView(ListView):
+    """Lista de pacientes."""
+
+    model = Paciente
+    template_name = "pacientes.html"
+    context_object_name = "pacientes"
+
+
+class PacienteCreateView(CreateView):
+    """Cadastro de pacientes."""
+
+    model = Paciente
+    fields = [
+        "nome",
+        "cpf",
+        "data_nascimento",
+        "endereco",
+        "telefone",
+        "email",
+    ]
+    template_name = "paciente_form.html"
+    success_url = reverse_lazy("paciente_list")
+
+
+class PacienteUpdateView(UpdateView):
+    """Edição de pacientes."""
+
+    model = Paciente
+    fields = [
+        "nome",
+        "cpf",
+        "data_nascimento",
+        "endereco",
+        "telefone",
+        "email",
+    ]
+    template_name = "paciente_form.html"
+    success_url = reverse_lazy("paciente_list")
+
+
+class PacienteDeleteView(DeleteView):
+    """Exclusão de pacientes."""
+
+    model = Paciente
+    template_name = "paciente_confirm_delete.html"
+    success_url = reverse_lazy("paciente_list")
+
+
+class MedicoListView(ListView):
+    """Lista de médicos."""
+
+    model = Medico
+    template_name = "medicos.html"
+    context_object_name = "medicos"
+
+
+class MedicoCreateView(CreateView):
+    """Cadastro de médicos."""
+
+    model = Medico
+    fields = [
+        "primeiro_nome",
+        "ultimo_nome",
+        "email",
+        "telefone",
+        "crm",
+        "especialidade",
+    ]
+    template_name = "medico_form.html"
+    success_url = reverse_lazy("medico_list")
+
+
+class MedicoUpdateView(UpdateView):
+    """Edição de médicos."""
+
+    model = Medico
+    fields = [
+        "primeiro_nome",
+        "ultimo_nome",
+        "email",
+        "telefone",
+        "crm",
+        "especialidade",
+    ]
+    template_name = "medico_form.html"
+    success_url = reverse_lazy("medico_list")
+
+
+class MedicoDeleteView(DeleteView):
+    """Exclusão de médicos."""
+
+    model = Medico
+    template_name = "medico_confirm_delete.html"
+    success_url = reverse_lazy("medico_list")
+
+
+class PedidoListView(ListView):
+    """Lista de pedidos."""
+
+    model = Pedido
+    template_name = "pedidos.html"
+    context_object_name = "pedidos"
+
+
+class PedidoCreateView(CreateView):
+    """Cadastro de pedidos."""
+
+    model = Pedido
+    fields = ["paciente", "medico", "descricao", "status"]
+    template_name = "pedido_form.html"
+    success_url = reverse_lazy("pedido_list")
+
+
+class PedidoUpdateView(UpdateView):
+    """Edição de pedidos."""
+
+    model = Pedido
+    fields = ["paciente", "medico", "descricao", "status"]
+    template_name = "pedido_form.html"
+    success_url = reverse_lazy("pedido_list")
+
+
+class PedidoDeleteView(DeleteView):
+    """Exclusão de pedidos."""
+
+    model = Pedido
+    template_name = "pedido_confirm_delete.html"
+    success_url = reverse_lazy("pedido_list")


### PR DESCRIPTION
## Summary
- implement CRUD views for Paciente, Medico and Pedido
- expose CRUD routes in `urls.py`

## Testing
- `python -m py_compile farmacia_project/farmacia/views.py farmacia_project/farmacia/urls.py`

------
https://chatgpt.com/codex/tasks/task_e_68483af92f50832baec7f3575cbcfa01