### PR TITLE
Add file upload field to Paciente

### DIFF
--- a/farmacia_project/farmacia/Templates/paciente_form.html
+++ b/farmacia_project/farmacia/Templates/paciente_form.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% load static %}
+
+{% block title %}FarmaSys - Paciente{% endblock %}
+
+{% block content %}
+<div class="container mx-auto p-6">
+    <h1 class="text-2xl font-semibold mb-4">{{ view.object.pk|default:'Novo' }} Paciente</h1>
+    <form method="post" enctype="multipart/form-data" class="space-y-4">
+        {% csrf_token %}
+        {{ form.as_p }}
+        <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded">Salvar</button>
+    </form>
+</div>
+{% endblock %}

--- a/farmacia_project/farmacia/forms.py
+++ b/farmacia_project/farmacia/forms.py
@@ -14,6 +14,7 @@ class PacienteForm(forms.ModelForm):
             "endereco",
             "telefone",
             "email",
+            "arquivo",
         ]
 
     def clean_cpf(self):

--- a/farmacia_project/farmacia/models.py
+++ b/farmacia_project/farmacia/models.py
@@ -8,6 +8,7 @@ class Paciente(models.Model):
     endereco = models.CharField(max_length=255, blank=True)
     telefone = models.CharField(max_length=20, blank=True)
     email = models.EmailField(blank=True)
+    arquivo = models.FileField(upload_to="uploads/pacientes/", null=True, blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 

--- a/farmacia_project/farmacia_projet/settings.py
+++ b/farmacia_project/farmacia_projet/settings.py
@@ -121,6 +121,10 @@ USE_TZ = True
 STATIC_URL = '/static/'
 STATICFILES_DIRS = [BASE_DIR / 'farmacia' / 'static']
 
+# Uploads de arquivos
+MEDIA_URL = '/media/'
+MEDIA_ROOT = BASE_DIR / 'media'
+
 # Default primary key field type
 # https://docs.djangoproject.com/en/3.2/ref/settings/#default-auto-field
 

--- a/farmacia_project/farmacia_projet/urls.py
+++ b/farmacia_project/farmacia_projet/urls.py
@@ -1,8 +1,13 @@
 from django.contrib import admin
 from django.urls import path, include
+from django.conf import settings
+from django.conf.urls.static import static
 
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('', include('farmacia.urls')),
 ]
+
+if settings.DEBUG:
+    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
## Summary
- allow uploading of files for Paciente records
- expose MEDIA settings and url for uploaded files
- create a simple Paciente form template capable of uploading files

## Testing
- `python farmacia_project/manage.py makemigrations farmacia` *(fails: ModuleNotFoundError: No module named 'django')*
- `python farmacia_project/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68483e382bb4832b911aed300886c8a8