### PR TITLE
Fix sidebar patients URL

### DIFF
--- a/farmacia_project/farmacia/Templates/includes/sidebar.html
+++ b/farmacia_project/farmacia/Templates/includes/sidebar.html
@@ -19,7 +19,7 @@
                 <i class="fas fa-shopping-cart"></i>
                 <span>Pedidos</span>
             </a>
-            <a href="{% url 'pacientes' %}" class="flex items-center space-x-3 p-3 rounded-lg {% if active == 'pacientes' %}bg-indigo-800 text-white{% else %}text-indigo-200 hover:bg-indigo-800 hover:text-white{% endif %}">
+            <a href="{% url 'paciente_list' %}" class="flex items-center space-x-3 p-3 rounded-lg {% if active == 'pacientes' %}bg-indigo-800 text-white{% else %}text-indigo-200 hover:bg-indigo-800 hover:text-white{% endif %}">
                 <i class="fas fa-users"></i>
                 <span>Pacientes</span>
               </a>


### PR DESCRIPTION
## Summary
- fix template sidebar link to use `paciente_list`

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68485a31a7a8832ba4351b532cfe7bb6